### PR TITLE
fix: Remove unexpected large top spacing in modal presentation (#33)

### DIFF
--- a/ios/ProgrammablewalletRnSdkModule.swift
+++ b/ios/ProgrammablewalletRnSdkModule.swift
@@ -181,6 +181,11 @@ public class ProgrammablewalletRnSdkModule: Module {
                 guard let sdkVc = self.sdkNavigationController else { return }
                 let topMostVC = UIApplication.shared.topMostViewController()
                 sdkVc.modalPresentationStyle = .overFullScreen
+                sdkVc.view.frame = UIScreen.main.bounds
+                // Configure to ignore safe area insets and extend behind the status bar
+                if #available(iOS 11.0, *) {
+                    sdkVc.additionalSafeAreaInsets = UIEdgeInsets(top: -sdkVc.view.safeAreaInsets.top, left: 0, bottom: 0, right: 0)
+                }
                 topMostVC?.present(sdkVc, animated: true)
                 print("moveTaskToFront")
             }

--- a/ios/RnWalletSdk.swift
+++ b/ios/RnWalletSdk.swift
@@ -236,6 +236,11 @@ public class RNWalletSdk: NSObject {
             guard let sdkVc = self.sdkNavigationController else { return }
             let topMostVC = UIApplication.shared.topMostViewController()
             sdkVc.modalPresentationStyle = .overFullScreen
+            sdkVc.view.frame = UIScreen.main.bounds
+            // Configure to ignore safe area insets and extend behind the status bar
+            if #available(iOS 11.0, *) {
+                sdkVc.additionalSafeAreaInsets = UIEdgeInsets(top: -sdkVc.view.safeAreaInsets.top, left: 0, bottom: 0, right: 0)
+            }
             topMostVC?.present(sdkVc, animated: true)
             print("moveTaskToFront")
         }


### PR DESCRIPTION
On iOS, even with modalPresentationStyle = .overFullScreen, the presented view controller's content was respecting safe area insets, causing a large blank area above the modal content (particularly visible with notches/status bars).

The fix:
- Set the view controller's frame to UIScreen.main.bounds to ensure full screen coverage
- Use additionalSafeAreaInsets with negative top value to offset the safe area, allowing the modal content to extend behind the status bar
- Added iOS 11.0+ availability check for the additionalSafeAreaInsets property

This applies to both RnWalletSdk.swift and ProgrammablewalletRnSdkModule.swift to cover both Bare React Native and Expo use cases.

Fixes: #33